### PR TITLE
Added : Rive Event System.

### DIFF
--- a/Source/Rive/Private/Rive/RiveFile.cpp
+++ b/Source/Rive/Private/Rive/RiveFile.cpp
@@ -160,7 +160,22 @@ bool URiveFile::GetBoolValue(const FString& InPropertyName) const
 #endif // !WITH_RIVE
 }
 
-int64 URiveFile::GetNumberValue(const FString& InPropertyName) const
+bool URiveFile::GetCustomBoolValue(const FString& InEventName, const FString& InPropertyName) const
+{
+    return false;
+}
+
+float URiveFile::GetCustomNumberValue(const FString& InEventName, const FString& InPropertyName) const
+{
+    return 0.0f;
+}
+
+const FString URiveFile::GetCustomStringValue(const FString& InEventName, const FString& InPropertyName) const
+{
+    return FString();
+}
+
+float URiveFile::GetNumberValue(const FString& InPropertyName) const
 {
 #if WITH_RIVE
 
@@ -172,11 +187,11 @@ int64 URiveFile::GetNumberValue(const FString& InPropertyName) const
         }
     }
 
-    return 0;
+    return 0.f;
 
 #else
 
-    return 0;
+    return 0.f;
 
 #endif // !WITH_RIVE
 }
@@ -228,7 +243,7 @@ void URiveFile::SetBoolValue(const FString& InPropertyName, bool bNewValue)
 #endif // WITH_RIVE
 }
 
-void URiveFile::SetNumberValue(const FString& InPropertyName, int64 NewValue)
+void URiveFile::SetNumberValue(const FString& InPropertyName, float NewValue)
 {
 #if WITH_RIVE
 

--- a/Source/Rive/Public/Rive/RiveFile.h
+++ b/Source/Rive/Public/Rive/RiveFile.h
@@ -176,23 +176,32 @@ public:
     UFUNCTION(BlueprintCallable, Category = Rive)
     void FireTrigger(const FString& InPropertyName) const;
 
-    UFUNCTION(BlueprintPure, Category = Rive)
+    UFUNCTION(BlueprintCallable, Category = Rive)
     bool GetBoolValue(const FString& InPropertyName) const;
 
-    UFUNCTION(BlueprintPure, Category = Rive)
-    int64 GetNumberValue(const FString& InPropertyName) const;
+    UFUNCTION(BlueprintCallable, Category = "Rive | Reported Events")
+    bool GetCustomBoolValue(const FString& InEventName, const FString& InPropertyName) const;
+
+    UFUNCTION(BlueprintCallable, Category = "Rive | Reported Events")
+    float GetCustomNumberValue(const FString& InEventName, const FString& InPropertyName) const;
+
+    UFUNCTION(BlueprintCallable, Category = "Rive | Reported Events")
+    const FString GetCustomStringValue(const FString& InEventName, const FString& InPropertyName) const;
+
+    UFUNCTION(BlueprintCallable, Category = Rive)
+    float GetNumberValue(const FString& InPropertyName) const;
 
     UFUNCTION(BlueprintPure, Category = Rive)
     FLinearColor GetDebugColor() const;
 
-    UFUNCTION(BlueprintPure, Category = Rive)
+    UFUNCTION(BlueprintCallable, Category = Rive)
     FVector2f GetLocalCoordinates(const FVector2f& InScreenPosition, const FBox2f& InScreenRect, const FIntPoint& InViewportSize) const;
 
     UFUNCTION(BlueprintCallable, Category = Rive)
     void SetBoolValue(const FString& InPropertyName, bool bNewValue);
 
     UFUNCTION(BlueprintCallable, Category = Rive)
-    void SetNumberValue(const FString& InPropertyName, int64 NewValue);
+    void SetNumberValue(const FString& InPropertyName, float NewValue);
 
     // TODO. We need function in URiveFile to calculate it , based on RiveFitType
     FIntPoint CalculateRenderTextureSize(const FIntPoint& InViewportSize) const;

--- a/Source/RiveCore/Private/Assets/URFile.cpp
+++ b/Source/RiveCore/Private/Assets/URFile.cpp
@@ -13,7 +13,9 @@ UE::Rive::Assets::FURFile::FURFile(const uint8* InBytes, uint32 InSize)
     : NativeFileSpan(InBytes, InSize)
 #endif // WITH_RIVE
 {
+#if WITH_RIVE
     FileAssetLoader = MakeUnique<FURFileAssetLoader>("");
+#endif // WITH_RIVE
 }
 
 #if WITH_RIVE

--- a/Source/RiveCore/Private/Core/UREvent.cpp
+++ b/Source/RiveCore/Private/Core/UREvent.cpp
@@ -1,0 +1,142 @@
+// Copyright Rive, Inc. All rights reserved.
+
+#include "Core/UREvent.h"
+
+#if WITH_RIVE
+THIRD_PARTY_INCLUDES_START
+#include "rive/custom_property_boolean.hpp"
+#include "rive/custom_property_number.hpp"
+#include "rive/custom_property_string.hpp"
+#include "rive/event.hpp"
+THIRD_PARTY_INCLUDES_END
+#endif // WITH_RIVE
+
+#if WITH_RIVE
+
+UE::Rive::Core::FUREvent::FUREvent(const rive::EventReport& InEventReport)
+	: DelayInSeconds(InEventReport.secondsDelay())
+	, BoolProperties()
+	, NumberProperties()
+	, StringProperties()
+{
+	if (rive::Event* NativeEvent = InEventReport.event())
+	{
+		Name = NativeEvent->name().c_str();
+
+		Type = NativeEvent->coreType();
+
+		const size_t NumProperties = NativeEvent->children().size();
+
+		if (NumProperties != 0)
+		{
+			for (size_t PropertyIndex = 0; PropertyIndex < NumProperties; ++PropertyIndex)
+			{
+				if (rive::Component* Child = NativeEvent->children().at(PropertyIndex))
+				{
+					if (!Child->is<rive::CustomProperty>())
+					{
+						continue;
+					}
+
+					if (rive::CustomProperty* Property = Child->as<rive::CustomProperty>())
+					{
+						FString PropertyName = Property->name().c_str();
+
+						switch (Property->coreType())
+						{
+							case 127: // Number Property
+							{
+								if (rive::CustomPropertyNumber* NumProperty = Property->as<rive::CustomPropertyNumber>())
+								{
+									NumberProperties.Add(PropertyName, NumProperty->propertyValue());
+								}
+
+								break;
+							}
+							case 129: // Boolean Property
+							{
+								if (rive::CustomPropertyBoolean* BoolProperty = Property->as<rive::CustomPropertyBoolean>())
+								{
+									BoolProperties.Add(PropertyName, BoolProperty->propertyValue());
+								}
+
+								break;
+							}
+							case 130: // String Property
+							{
+								if (rive::CustomPropertyString* StrProperty = Property->as<rive::CustomPropertyString>())
+								{
+									StringProperties.Add(PropertyName, StrProperty->propertyValue().c_str());
+								}
+
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+bool UE::Rive::Core::FUREvent::GetBoolValue(const FString& InPropertyName) const
+{
+	if (HasBoolValue(InPropertyName))
+	{
+		return BoolProperties[InPropertyName];
+	}
+
+	return false;
+}
+
+const FString& UE::Rive::Core::FUREvent::GetName() const
+{
+	return Name;
+}
+
+float UE::Rive::Core::FUREvent::GetDelayInSeconds() const
+{
+	return DelayInSeconds;
+}
+
+float UE::Rive::Core::FUREvent::GetNumberValue(const FString& InPropertyName) const
+{
+	if (HasNumberValue(InPropertyName))
+	{
+		return NumberProperties[InPropertyName];
+	}
+
+	return 0.f;
+}
+
+const FString UE::Rive::Core::FUREvent::GetStringValue(const FString& InPropertyName) const
+{
+	if (HasStringValue(InPropertyName))
+	{
+		return StringProperties[InPropertyName];
+	}
+
+	return "None";
+}
+
+uint8 UE::Rive::Core::FUREvent::GetType() const
+{
+	return Type;
+}
+
+bool UE::Rive::Core::FUREvent::HasBoolValue(const FString& InPropertyName) const
+{
+	return BoolProperties.Contains(InPropertyName);
+}
+
+bool UE::Rive::Core::FUREvent::HasNumberValue(const FString& InPropertyName) const
+{
+	return NumberProperties.Contains(InPropertyName);
+}
+
+bool UE::Rive::Core::FUREvent::HasStringValue(const FString& InPropertyName) const
+{
+	return StringProperties.Contains(InPropertyName);
+}
+
+#endif // WITH_RIVE

--- a/Source/RiveCore/Private/Core/URStateMachine.cpp
+++ b/Source/RiveCore/Private/Core/URStateMachine.cpp
@@ -97,7 +97,7 @@ bool UE::Rive::Core::FURStateMachine::GetBoolValue(const FString& InPropertyName
     return false;
 }
 
-uint32 UE::Rive::Core::FURStateMachine::GetNumberValue(const FString& InPropertyName) const
+float UE::Rive::Core::FURStateMachine::GetNumberValue(const FString& InPropertyName) const
 {
     if (NativeStateMachinePtr)
     {
@@ -135,7 +135,7 @@ void UE::Rive::Core::FURStateMachine::SetBoolValue(const FString& InPropertyName
     UE_LOG(LogRiveCore, Error, TEXT("Could not get the boolean property with given name '%s' as we have detected an empty state machine."), *InPropertyName);
 }
 
-void UE::Rive::Core::FURStateMachine::SetNumberValue(const FString& InPropertyName, uint32 NewValue)
+void UE::Rive::Core::FURStateMachine::SetNumberValue(const FString& InPropertyName, float NewValue)
 {
     if (NativeStateMachinePtr)
     {
@@ -194,6 +194,51 @@ bool UE::Rive::Core::FURStateMachine::OnMouseButtonUp(const FVector2f& NewPositi
     UE_LOG(LogRiveCore, Error, TEXT("Could not update state machine with mouse button up event as we have detected an empty state machine."));
 
     return false;
+}
+
+const TArray<UE::Rive::Core::FUREventPtr>& UE::Rive::Core::FURStateMachine::GetReportedEvents()
+{
+    PopulateReportedEvents();
+
+    return ReportedEvents;
+}
+
+bool UE::Rive::Core::FURStateMachine::HasAnyReportedEvents() const
+{
+    if (NativeStateMachinePtr)
+    {
+        return NativeStateMachinePtr->reportedEventCount() != 0;
+    }
+ 
+    UE_LOG(LogRiveCore, Warning, TEXT("Could not check for reported event(s) as we have detected an empty state machine."));
+
+    return false;
+}
+
+void UE::Rive::Core::FURStateMachine::PopulateReportedEvents()
+{
+    if (HasAnyReportedEvents()) // Only populate when we have atleast one reported event.
+    {
+        if (NativeStateMachinePtr)
+        {
+            const size_t NumReportedEvents = NativeStateMachinePtr->reportedEventCount();
+
+            ReportedEvents.Reset(NumReportedEvents);
+
+            for (size_t EventIndex = 0; EventIndex < NumReportedEvents; ++EventIndex)
+            {
+                ReportedEvents[EventIndex] = MakeUnique<FUREvent>(NativeStateMachinePtr->reportedEventAt(EventIndex));
+            }
+        }
+        else
+        {
+            UE_LOG(LogRiveCore, Warning, TEXT("Could not get reported event(s) as we have detected an empty state machine."));
+        }
+    }
+    else
+    {
+        ReportedEvents.Empty();
+    }
 }
 
 UE_ENABLE_OPTIMIZATION

--- a/Source/RiveCore/Public/Core/UREvent.h
+++ b/Source/RiveCore/Public/Core/UREvent.h
@@ -1,0 +1,84 @@
+// Copyright Rive, Inc. All rights reserved.
+
+#pragma once
+
+#if WITH_RIVE
+THIRD_PARTY_INCLUDES_START
+#include "rive/animation/state_machine_instance.hpp"
+#include "rive/custom_property.hpp"
+THIRD_PARTY_INCLUDES_END
+#endif // WITH_RIVE
+
+namespace UE::Rive::Core
+{
+	class FUREvent;
+
+	/**
+	 * Type definition for unique pointer reference to the instance of FUREvent.
+	 */
+	using FUREventPtr = TUniquePtr<FUREvent>;
+
+	/**
+	 * Represents an event reported by a StateMachine.
+	 */
+	class RIVECORE_API FUREvent
+	{
+		/**
+		 * Structor(s)
+		 */
+
+	public:
+
+		FUREvent() = default;
+
+		~FUREvent() = default;
+
+#if WITH_RIVE
+
+		explicit FUREvent(const rive::EventReport& InEventReport);
+
+		/**
+		 * Implementation(s)
+		 */
+
+	public:
+
+		bool GetBoolValue(const FString& InPropertyName) const;
+
+		const FString& GetName() const;
+
+		float GetDelayInSeconds() const;
+
+		float GetNumberValue(const FString& InPropertyName) const;
+
+		const FString GetStringValue(const FString& InPropertyName) const;
+
+		uint8 GetType() const;
+
+		bool HasBoolValue(const FString& InPropertyName) const;
+
+		bool HasNumberValue(const FString& InPropertyName) const;
+
+		bool HasStringValue(const FString& InPropertyName) const;
+
+		/**
+		 * Attribute(s)
+		 */
+
+	private:
+
+		FString Name = "None";
+
+		float DelayInSeconds = 0.f;
+
+		uint8 Type = 0U;
+
+		TMap<FString, bool> BoolProperties;
+
+		TMap<FString, float> NumberProperties;
+
+		TMap<FString, FString> StringProperties;
+
+#endif // WITH_RIVE
+	};
+}

--- a/Source/RiveCore/Public/Core/URStateMachine.h
+++ b/Source/RiveCore/Public/Core/URStateMachine.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "Core/UREvent.h"
+
 #if WITH_RIVE
 THIRD_PARTY_INCLUDES_START
 #include "rive/artboard.hpp"
@@ -53,17 +55,25 @@ namespace UE::Rive::Core
 
         bool GetBoolValue(const FString& InPropertyName) const;
 
-        uint32 GetNumberValue(const FString& InPropertyName) const;
+        float GetNumberValue(const FString& InPropertyName) const;
 
         void SetBoolValue(const FString& InPropertyName, bool bNewValue);
 
-        void SetNumberValue(const FString& InPropertyName, uint32 NewValue);
+        void SetNumberValue(const FString& InPropertyName, float NewValue);
 
         bool OnMouseButtonDown(const FVector2f& NewPosition);
 
         bool OnMouseMove(const FVector2f& NewPosition);
 
         bool OnMouseButtonUp(const FVector2f& NewPosition);
+
+        const TArray<FUREventPtr>& GetReportedEvents();
+
+        bool HasAnyReportedEvents() const;
+
+    private:
+
+        void PopulateReportedEvents();
 
         /**
          * Attribute(s)
@@ -72,6 +82,8 @@ namespace UE::Rive::Core
     private:
 
         std::unique_ptr<rive::StateMachineInstance> NativeStateMachinePtr = nullptr;
+
+        TArray<FUREventPtr> ReportedEvents;
 
 #endif // WITH_RIVE
     };


### PR DESCRIPTION
Rive Event Listeners

User can retrieve the following type of values from a (named) reported event(s) from Rive SDK.

- Boolean Value(s)
- String Value(s)
- Number Value(s)

These are not exposed to blueprint at the moment. But we will eventually do them later.