### PR TITLE
UR-114 - Handling of Rive Events in Blueprint

### DIFF
--- a/Rive.uplugin
+++ b/Rive.uplugin
@@ -29,6 +29,11 @@
 			"Name": "RiveEditor",
 			"Type": "Editor",
 			"LoadingPhase": "Default"
+		},
+		{
+			"Name": "RiveCore",
+			"Type": "Runtime",
+			"LoadingPhase": "None"
 		}
 	]
 }

--- a/Source/Rive/Public/Rive/RiveTexture.h
+++ b/Source/Rive/Public/Rive/RiveTexture.h
@@ -53,6 +53,7 @@ protected:
 	 */
 	virtual void ResizeRenderTargets(const FVector2f InNewSize);
 
+	virtual void OnResourceInitialized_RenderThread(FRHICommandListImmediate& RHICmdList, FTextureRHIRef& NewResource) const {};
 protected:
 
 	/**

--- a/Source/RiveCore/Private/Assets/URFileAssetLoader.cpp
+++ b/Source/RiveCore/Private/Assets/URFileAssetLoader.cpp
@@ -23,17 +23,16 @@ UE::Rive::Assets::FURFileAssetLoader::FURFileAssetLoader(UObject* InOuter, TMap<
 bool UE::Rive::Assets::FURFileAssetLoader::loadContents(rive::FileAsset& InAsset, rive::Span<const uint8> InBandBytes,
                                                         rive::Factory* InFactory)
 {
-	rive::Span<const uint8>* AssetBytes = &InBandBytes;
-	bool bUseInBand = InBandBytes.size() > 0;
-
-
+	const rive::Span<const uint8>* AssetBytes = &InBandBytes;
+	const bool bUseInBand = InBandBytes.size() > 0;
+	
 	// We can take two paths here
 	// 1. Either search for a file to load off disk (or in the Unreal registry)
 	// 2. Or use InBandbytes if no other options are found to load
 	// Unity version prefers disk assets, over InBand, if they exist, allowing overrides
-
+	
 	URiveAsset* RiveAsset = nullptr;
-	TObjectPtr<URiveAsset>* RiveAssetPtr = Assets.Find(InAsset.assetId());
+	const TObjectPtr<URiveAsset>* RiveAssetPtr = Assets.Find(InAsset.assetId());
 	if (RiveAssetPtr == nullptr)
 	{
 		if (!bUseInBand)
@@ -41,9 +40,12 @@ bool UE::Rive::Assets::FURFileAssetLoader::loadContents(rive::FileAsset& InAsset
 			UE_LOG(LogRiveCore, Error, TEXT("Could not find pre-loaded asset. This means the initial import probably failed."));
 			return false;
 		}
-
-		RiveAsset = NewObject<URiveAsset>(Outer, URiveAsset::StaticClass(), MakeUniqueObjectName(Outer, URiveAsset::StaticClass(), FName(FString::Printf(TEXT("%d"), InAsset.assetId()))), RF_Transient);
-	} else
+		
+		RiveAsset = NewObject<URiveAsset>(Outer, URiveAsset::StaticClass(),
+			MakeUniqueObjectName(Outer, URiveAsset::StaticClass(), FName{FString::Printf(TEXT("%d"),InAsset.assetId())}),
+			RF_Transient);
+	}
+	else
 	{
 		RiveAsset = RiveAssetPtr->Get();
 	}

--- a/Source/RiveCore/Private/URStateMachine.cpp
+++ b/Source/RiveCore/Private/URStateMachine.cpp
@@ -102,18 +102,6 @@ void UE::Rive::Core::FURStateMachine::FireTrigger(const FString& InPropertyName)
     UE_LOG(LogRiveCore, Error, TEXT("Could not fire the trigger with given name '%s' as we could not find it."), *InPropertyName);
 }
 
-void UE::Rive::Core::FURStateMachine::FireEvent(const FString& InPropertyName, float DelaySeconds) const
-{
-    Renderer::IRiveRenderer* RiveRenderer = UE::Rive::Renderer::IRiveRendererModule::Get().GetRenderer();
-    FScopeLock Lock(&RiveRenderer->GetThreadDataCS());
-    
-    if (!NativeStateMachinePtr)
-    {
-        return;
-    }
-    
-}
-
 bool UE::Rive::Core::FURStateMachine::GetBoolValue(const FString& InPropertyName) const
 {
     Renderer::IRiveRenderer* RiveRenderer = UE::Rive::Renderer::IRiveRendererModule::Get().GetRenderer();

--- a/Source/RiveCore/Public/Assets/RiveAsset.h
+++ b/Source/RiveCore/Public/Assets/RiveAsset.h
@@ -34,16 +34,16 @@ class RIVECORE_API URiveAsset : public UObject
 public:
 	virtual void PostLoad() override;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere, Category=Rive)
 	uint32 Id;
 	
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere, Category=Rive)
 	ERiveAssetType Type;
 	
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere, Category=Rive)
 	FString Name;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere, Category=Rive)
 	bool bIsInBand;
 
 	UPROPERTY()

--- a/Source/RiveCore/Public/RiveArtboard.h
+++ b/Source/RiveCore/Public/RiveArtboard.h
@@ -64,7 +64,7 @@ public:
 	bool TriggerNamedRiveEvent(const FString& EventName, float ReportedDelaySeconds);
 	
 #if WITH_RIVE
-
+	
 	void Initialize(rive::File* InNativeFilePtr, const UE::Rive::Renderer::IRiveRenderTargetPtr& InRiveRenderTarget);
 	void Initialize(rive::File* InNativeFilePtr, UE::Rive::Renderer::IRiveRenderTargetPtr InRiveRenderTarget, int32 InIndex, const FString& InStateMachineName = TEXT_EMPTY, ERiveFitType InFitType = ERiveFitType::Cover, ERiveAlignment InAlignment = ERiveAlignment::Center);
 	void Initialize(rive::File* InNativeFilePtr, UE::Rive::Renderer::IRiveRenderTargetPtr InRiveRenderTarget, const FString& InName, const FString& InStateMachineName = TEXT_EMPTY, ERiveFitType InFitType = ERiveFitType::Cover, ERiveAlignment InAlignment = ERiveAlignment::Center);

--- a/Source/RiveCore/Public/URStateMachine.h
+++ b/Source/RiveCore/Public/URStateMachine.h
@@ -42,7 +42,7 @@ namespace UE::Rive::Core
     	}
 #if WITH_RIVE
 
-        explicit FURStateMachine(rive::ArtboardInstance* InNativeArtboardInst, const FString& InStateMachineName = TEXT_EMPTY);
+        explicit FURStateMachine(rive::ArtboardInstance* InNativeArtboardInst, const FString& InStateMachineName);
 
         /**
          * Implementation(s)
@@ -58,8 +58,6 @@ namespace UE::Rive::Core
 
         void FireTrigger(const FString& InPropertyName) const;
     	
-        void FireEvent(const FString& InPropertyName, float DelaySeconds) const;
-
         bool GetBoolValue(const FString& InPropertyName) const;
 
         float GetNumberValue(const FString& InPropertyName) const;

--- a/Source/RiveCore/RiveCore.Build.cs
+++ b/Source/RiveCore/RiveCore.Build.cs
@@ -40,6 +40,7 @@ public class RiveCore : ModuleRules
 		PrivateDependencyModuleNames.AddRange(
 			new string[]
 			{
+				"Core",
 				"CoreUObject",
 				"Engine",
                 "Projects",

--- a/Source/RiveEditor/Private/Factories/RiveFileFactory.cpp
+++ b/Source/RiveEditor/Private/Factories/RiveFileFactory.cpp
@@ -13,7 +13,6 @@ URiveFileFactory::URiveFileFactory(const FObjectInitializer& ObjectInitializer)
     Formats.Add(TEXT("riv;Rive Animation File"));
 
     bEditorImport = true;
-
     bEditAfterNew = true;
 }
 
@@ -25,19 +24,16 @@ bool URiveFileFactory::FactoryCanImport(const FString& Filename)
 UObject* URiveFileFactory::FactoryCreateFile(UClass* InClass, UObject* InParent, FName InName, EObjectFlags InFlags, const FString& InFilename, const TCHAR* Params, FFeedbackContext* Warn, bool& bOutOperationCanceled)
 {
     const FString FileExtension = FPaths::GetExtension(InFilename);
-
     const TCHAR* Type = *FileExtension;
 
     GEditor->GetEditorSubsystem<UImportSubsystem>()->BroadcastAssetPreImport(this, InClass, InParent, InName, Type);
 
     URiveFile* RiveFile = NewObject<URiveFile>(InParent, InClass, InName, InFlags | RF_Public);
-
     check(RiveFile);
 
     if (!FPaths::FileExists(InFilename))
     {
         UE_LOG(LogRiveEditor, Error, TEXT("Rive file %s does not exist!"), *InFilename);
-
         return nullptr;
     }
 
@@ -45,7 +41,6 @@ UObject* URiveFileFactory::FactoryCreateFile(UClass* InClass, UObject* InParent,
     if (!FFileHelper::LoadFileToArray(FileBuffer, *InFilename)) // load entire DNA file into the array
     {
         UE_LOG(LogRiveEditor, Error, TEXT("Could not read DNA file %s!"), *InFilename);
-
         return nullptr;
     }
     
@@ -54,8 +49,6 @@ UObject* URiveFileFactory::FactoryCreateFile(UClass* InClass, UObject* InParent,
         UE_LOG(LogRiveEditor, Error, TEXT("Could not import riv file"));
         return nullptr;
     }
-
-    RiveFile->Initialize();
     
     // Create Rive UMG
     if (!FRiveWidgetFactory(RiveFile).Create())

--- a/Source/RiveEditor/Private/Factories/RiveFileInstanceFactory.cpp
+++ b/Source/RiveEditor/Private/Factories/RiveFileInstanceFactory.cpp
@@ -3,6 +3,7 @@
 
 #include "RiveFileInstanceFactory.h"
 
+#include "Logs/RiveEditorLog.h"
 #include "Rive/RiveFile.h"
 
 URiveFileInstanceFactory::URiveFileInstanceFactory(const FObjectInitializer& ObjectInitializer)
@@ -15,9 +16,15 @@ URiveFileInstanceFactory::URiveFileInstanceFactory(const FObjectInitializer& Obj
 UObject* URiveFileInstanceFactory::FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags InFlags,
                                                     UObject* Context, FFeedbackContext* Warn)
 {
-
 	auto NewRiveFileInstance = NewObject<URiveFile>(InParent, URiveFile::StaticClass(), InName, RF_Public | RF_Standalone);
 	NewRiveFileInstance->ParentRiveFile = InitialRiveFile;
-	NewRiveFileInstance->Initialize();
+
+	TArray<uint8> EmptyData{};
+	if (!NewRiveFileInstance->EditorImport(FString{},EmptyData))
+	{
+		UE_LOG(LogRiveEditor, Error, TEXT("Could not create instance of RiveFile '%s'"), *GetFullNameSafe(InitialRiveFile));
+		return nullptr;
+	}
+	
 	return NewRiveFileInstance;
 }

--- a/Source/RiveRenderer/Private/Platform/RiveRenderTargetD3D11.h
+++ b/Source/RiveRenderer/Private/Platform/RiveRenderTargetD3D11.h
@@ -7,7 +7,7 @@
 #if PLATFORM_WINDOWS
 
 #if WITH_RIVE
-#include "PreRiveHeaders.h"
+#include "RiveCore/Public/PreRiveHeaders.h"
 THIRD_PARTY_INCLUDES_START
 #include "rive/refcnt.hpp"
 THIRD_PARTY_INCLUDES_END

--- a/Source/RiveRenderer/Private/Platform/RiveRenderTargetMetal.cpp
+++ b/Source/RiveRenderer/Private/Platform/RiveRenderTargetMetal.cpp
@@ -11,14 +11,13 @@
 #include <Metal/Metal.h>
 
 #if WITH_RIVE
+#include "RiveCore/Public/PreRiveHeaders.h"
 THIRD_PARTY_INCLUDES_START
 #include "rive/artboard.hpp"
 #include "rive/pls/pls_renderer.hpp"
 #include "rive/pls/metal/pls_render_context_metal_impl.h"
 THIRD_PARTY_INCLUDES_END
 #endif // WITH_RIVE
-
-UE_DISABLE_OPTIMIZATION
 
 UE::Rive::Renderer::Private::FRiveRenderTargetMetal::FRiveRenderTargetMetal(const TSharedRef<FRiveRenderer>& InRiveRenderer, const FName& InRiveName, UTexture2DDynamic* InRenderTarget)
     : FRiveRenderTarget(InRiveRenderer, InRiveName, InRenderTarget)
@@ -54,6 +53,9 @@ void UE::Rive::Renderer::Private::FRiveRenderTargetMetal::CacheTextureTarget_Ren
     
     if (PixelFormat != PF_R8G8B8A8)
     {
+        const FString PixelFormatString = GetPixelFormatString(InTexture->GetFormat());
+        UE_LOG(LogRiveRenderer, Error, TEXT("Texture Target has the wrong Pixel Format '%s' (not PF_R8G8B8A8)"), *PixelFormatString);
+
         return;
     }
     
@@ -67,8 +69,9 @@ void UE::Rive::Renderer::Private::FRiveRenderTargetMetal::CacheTextureTarget_Ren
         id<MTLTexture> MetalTexture = (id<MTLTexture>)InTexture->GetNativeResource();
         
         check(MetalTexture);
-        
-        UE_LOG(LogRiveRenderer, Warning, TEXT("MetalTexture texture %dx%d"), MetalTexture.width, MetalTexture.height);
+        NSUInteger Format = MetalTexture.pixelFormat;
+        UE_LOG(LogRiveRenderer, Verbose, TEXT("MetalTexture texture %dx%d"), MetalTexture.width, MetalTexture.height);
+        UE_LOG(LogRiveRenderer, Verbose, TEXT("  format: %d (MTLPixelFormatRGBA8Unorm_sRGB: %d , MTLPixelFormatRGBA8Unorm: %d)"), Format, MTLPixelFormatRGBA8Unorm_sRGB, MTLPixelFormatRGBA8Unorm);
 
 #if WITH_RIVE
         if (CachedPLSRenderTargetMetal)
@@ -94,6 +97,5 @@ rive::rcp<rive::pls::PLSRenderTarget> UE::Rive::Renderer::Private::FRiveRenderTa
 }
 #endif // WITH_RIVE
 
-UE_ENABLE_OPTIMIZATION
 
 #endif // PLATFORM_APPLE

--- a/Source/RiveRenderer/Private/Platform/RiveRenderTargetMetal.h
+++ b/Source/RiveRenderer/Private/Platform/RiveRenderTargetMetal.h
@@ -7,6 +7,7 @@
 #include "RiveRenderTarget.h"
 
 #if WITH_RIVE
+#include "RiveCore/Public/PreRiveHeaders.h"
 THIRD_PARTY_INCLUDES_START
 #include "rive/refcnt.hpp"
 THIRD_PARTY_INCLUDES_END
@@ -46,7 +47,6 @@ namespace UE::Rive::Renderer::Private
     protected:
 
         virtual rive::rcp<rive::pls::PLSRenderTarget> GetRenderTarget() const override;
-        virtual void EndFrame() const override;
         
         //~ END : FRiveRenderTarget Interface
         

--- a/Source/RiveRenderer/Private/Platform/RiveRenderTargetOpenGL.cpp
+++ b/Source/RiveRenderer/Private/Platform/RiveRenderTargetOpenGL.cpp
@@ -14,6 +14,7 @@
 
 
 #if WITH_RIVE
+#include "RiveCore/Public/PreRiveHeaders.h"
 THIRD_PARTY_INCLUDES_START
 #include "rive/artboard.hpp"
 #include "rive/pls/pls_renderer.hpp"

--- a/Source/RiveRenderer/Private/Platform/RiveRenderTargetOpenGL.h
+++ b/Source/RiveRenderer/Private/Platform/RiveRenderTargetOpenGL.h
@@ -6,6 +6,7 @@
 #include "RiveRenderTarget.h"
 
 #if WITH_RIVE
+#include "RiveCore/Public/PreRiveHeaders.h"
 THIRD_PARTY_INCLUDES_START
 #include "rive/refcnt.hpp"
 THIRD_PARTY_INCLUDES_END

--- a/Source/RiveRenderer/Private/Platform/RiveRendererD3D11.cpp
+++ b/Source/RiveRenderer/Private/Platform/RiveRendererD3D11.cpp
@@ -9,7 +9,7 @@
 #include "ID3D11DynamicRHI.h"
 
 #if WITH_RIVE
-#include "PreRiveHeaders.h"
+#include "RiveCore/Public/PreRiveHeaders.h"
 THIRD_PARTY_INCLUDES_START
 #include "rive/pls/d3d/pls_render_context_d3d_impl.hpp"
 #include "rive/pls/pls_renderer.hpp"

--- a/Source/RiveRenderer/Private/Platform/RiveRendererD3D11.h
+++ b/Source/RiveRenderer/Private/Platform/RiveRendererD3D11.h
@@ -7,7 +7,7 @@
 #if PLATFORM_WINDOWS
 
 #if WITH_RIVE
-#include "PreRiveHeaders.h"
+#include "RiveCore/Public/PreRiveHeaders.h"
 THIRD_PARTY_INCLUDES_START
 #include "Windows/AllowWindowsPlatformTypes.h"
 #include "Windows/MinWindows.h"

--- a/Source/RiveRenderer/Private/Platform/RiveRendererMetal.cpp
+++ b/Source/RiveRenderer/Private/Platform/RiveRendererMetal.cpp
@@ -11,6 +11,7 @@
 #include <Metal/Metal.h>
 
 #if WITH_RIVE
+#include "RiveCore/Public/PreRiveHeaders.h"
 THIRD_PARTY_INCLUDES_START
 #include "rive/artboard.hpp"
 #include "rive/pls/metal/pls_render_context_metal_impl.h"

--- a/Source/RiveRenderer/Private/RiveRenderTarget.cpp
+++ b/Source/RiveRenderer/Private/RiveRenderTarget.cpp
@@ -7,6 +7,7 @@
 #include "Engine/Texture2DDynamic.h"
 #include "Logs/RiveRendererLog.h"
 
+#include "RiveCore/Public/PreRiveHeaders.h"
 THIRD_PARTY_INCLUDES_START
 #include "rive/artboard.hpp"
 #include "rive/pls/pls_renderer.hpp"
@@ -17,9 +18,9 @@ FTimespan UE::Rive::Renderer::Private::FRiveRenderTarget::ResetTimeLimit = FTime
 UE_DISABLE_OPTIMIZATION
 
 UE::Rive::Renderer::Private::FRiveRenderTarget::FRiveRenderTarget(const TSharedRef<FRiveRenderer>& InRiveRenderer, const FName& InRiveName, UTexture2DDynamic* InRenderTarget)
-	: RiveRenderer(InRiveRenderer)
-	, RiveName(InRiveName)
+	: RiveName(InRiveName)
 	, RenderTarget(InRenderTarget)
+	, RiveRenderer(InRiveRenderer)
 {
 	RIVE_DEBUG_FUNCTION_INDENT;
 }

--- a/Source/RiveRenderer/Private/RiveRenderTarget.h
+++ b/Source/RiveRenderer/Private/RiveRenderTarget.h
@@ -5,7 +5,7 @@
 #include "IRiveRenderTarget.h"
 
 #if WITH_RIVE
-#include "PreRiveHeaders.h"
+#include "RiveCore/Public/PreRiveHeaders.h"
 THIRD_PARTY_INCLUDES_START
 #include "rive/refcnt.hpp"
 THIRD_PARTY_INCLUDES_END

--- a/Source/RiveRenderer/Private/RiveRenderer.h
+++ b/Source/RiveRenderer/Private/RiveRenderer.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "IRiveRenderer.h"
+#include "RiveTypes.h"
 
 #if WITH_RIVE
 
@@ -36,7 +37,7 @@ namespace UE::Rive::Renderer::Private
 
         virtual void Initialize() override;
 
-        virtual bool IsInitialized() const override { return bIsInitialized; }
+        virtual bool IsInitialized() const override { return InitializationState == ERiveInitState::Initialized; }
 
         virtual void QueueTextureRendering(TObjectPtr<URiveFile> InRiveFile) override;
 
@@ -45,6 +46,8 @@ namespace UE::Rive::Renderer::Private
         virtual UTextureRenderTarget2D* CreateDefaultRenderTarget(FIntPoint InTargetSize) override;
 
         virtual FCriticalSection& GetThreadDataCS() override { return ThreadDataCS; }
+
+        virtual void CallOrRegister_OnInitialized(FOnRendererInitialized::FDelegate&& Delegate) override;
 
 #if WITH_RIVE
 
@@ -77,7 +80,7 @@ namespace UE::Rive::Renderer::Private
         mutable FCriticalSection ThreadDataCS;
 
     protected:
-
-        bool bIsInitialized = false;
+        ERiveInitState InitializationState = ERiveInitState::Uninitialized;
+        FOnRendererInitialized OnInitializedDelegate;
     };
 }

--- a/Source/RiveRenderer/Public/IRiveRenderTarget.h
+++ b/Source/RiveRenderer/Public/IRiveRenderTarget.h
@@ -6,8 +6,8 @@
 
 enum class ERiveFitType : uint8;
 
+#include "RiveCore/Public/PreRiveHeaders.h"
 THIRD_PARTY_INCLUDES_START
-#include "PreRiveHeaders.h"
 #undef  PI // redefined in rive/math/math_types.hpp
 #include "rive/pls/pls.hpp"
 THIRD_PARTY_INCLUDES_END

--- a/Source/RiveRenderer/Public/IRiveRenderer.h
+++ b/Source/RiveRenderer/Public/IRiveRenderer.h
@@ -44,7 +44,8 @@ namespace UE::Rive::Renderer
          */
 
     public:
-
+        DECLARE_MULTICAST_DELEGATE_OneParam( FOnRendererInitialized, IRiveRenderer* /* RiveRenderer */ );
+        
         virtual ~IRiveRenderer() = default;
 
         /**
@@ -68,6 +69,8 @@ namespace UE::Rive::Renderer
         virtual UTextureRenderTarget2D* CreateDefaultRenderTarget(FIntPoint InTargetSize) = 0;
 
         virtual FCriticalSection& GetThreadDataCS() = 0;
+
+        virtual void CallOrRegister_OnInitialized(FOnRendererInitialized::FDelegate&& Delegate) = 0;
     
 #if WITH_RIVE
 

--- a/Source/RiveRenderer/Public/RiveRenderCommand.h
+++ b/Source/RiveRenderer/Public/RiveRenderCommand.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "RiveTypes.h"
-#include "PreRiveHeaders.h"
+#include "RiveCore/Public/PreRiveHeaders.h"
 THIRD_PARTY_INCLUDES_START
 #include "rive/math/mat2d.hpp"
 THIRD_PARTY_INCLUDES_END
@@ -46,30 +46,30 @@ public:
 	{
 	};
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category=Rive)
 	ERiveRenderCommandType Type;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category=Rive)
 	ERiveFitType FitType;
 
 	// UPROPERTY(BlueprintReadWrite)
 	rive::Artboard* NativeArtboard = nullptr;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category=Rive)
 	float X;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category=Rive)
 	float Y;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category=Rive)
 	float X2;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category=Rive)
 	float Y2;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category=Rive)
 	float TX;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category=Rive)
 	float TY;
 };

--- a/Source/RiveRenderer/Public/RiveTypes.h
+++ b/Source/RiveRenderer/Public/RiveTypes.h
@@ -6,7 +6,7 @@
 #include "RiveTypes.generated.h"
 
 USTRUCT(Blueprintable)
-struct RIVECORE_API FRiveStateMachineEvent
+struct RIVERENDERER_API FRiveStateMachineEvent
 {
 	GENERATED_BODY()
 
@@ -57,7 +57,7 @@ enum class ERiveBlendMode : uint8
 };
 
 USTRUCT(BlueprintType)
-struct RIVECORE_API FRiveAlignment
+struct RIVERENDERER_API FRiveAlignment
 {
 	GENERATED_BODY()
 
@@ -98,4 +98,13 @@ public:
 
 		return Center;
 	}
+};
+
+UENUM(BlueprintType)
+enum class ERiveInitState : uint8
+{
+	Uninitialized = 0,
+	Deinitializing = 1,
+	Initializing = 2,
+	Initialized = 3,
 };

--- a/Source/RiveRenderer/RiveRenderer.Build.cs
+++ b/Source/RiveRenderer/RiveRenderer.Build.cs
@@ -27,8 +27,7 @@ public class RiveRenderer : ModuleRules
 		PublicDependencyModuleNames.AddRange(
 			new string[]
 			{
-				"Core",
-				"RiveCore"
+				"Core"
 			}
 		);
 			
@@ -42,7 +41,6 @@ public class RiveRenderer : ModuleRules
                 "RHI",
 				"RenderCore",
 				"Renderer",
-				"RiveCore",
 				"RiveLibrary",
 			}
 		);


### PR DESCRIPTION
- Initial handling of Rive Events in Blueprints, via the Artboard. Currently exposed the current Artboard in BP for ease of use
- Moving of the rive file loading on GameThread to create all UObjects in GT
- Moving of the StateMachine Update on GameThread to ensure events are called directly and on the right thread
- Addition of Event/Input/Artboard/StateMachine names in the UI for ease of working. Should be improved over time
- Other minor fixes