### PR TITLE
Make sure to reset URiveActor artboards between begin and end playineditor

### DIFF
--- a/Source/Rive/Private/Game/RiveActor.cpp
+++ b/Source/Rive/Private/Game/RiveActor.cpp
@@ -95,6 +95,13 @@ void ARiveActor::BeginPlay()
 {
 	RequestGameDisplay();
 
+	UWorld* ActorWorld = GetWorld();
+
+	if (ActorWorld && (ActorWorld->WorldType == EWorldType::PIE))
+	{
+		RiveFile->InstantiateArtboard();
+	}
+	
 	Super::BeginPlay();
 }
 
@@ -110,6 +117,11 @@ void ARiveActor::EndPlay(const EEndPlayReason::Type EndPlayReason)
 		{
 			ScreenUserWidget->Hide();
 		}
+	}
+
+	if (EndPlayReason == EEndPlayReason::EndPlayInEditor)
+	{
+		RiveFile->InstantiateArtboard();
 	}
 }
 

--- a/Source/Rive/Public/Rive/RiveFile.h
+++ b/Source/Rive/Public/Rive/RiveFile.h
@@ -123,7 +123,7 @@ public:
 	 * Initialize this Rive file by creating the Render Targets and importing the native Rive File 
 	 */
 	void Initialize();
-
+	void InstantiateArtboard(bool bRaiseArtboardChangedEvent = true);
 	void SetWidgetClass(TSubclassOf<UUserWidget> InWidgetClass);
 
 	TSubclassOf<UUserWidget> GetWidgetClass() const { return WidgetClass; }
@@ -143,7 +143,6 @@ private:
 	FOnRiveFileInitialized OnInitializedDelegate;
 	
 protected:
-	void InstantiateArtboard(bool bRaiseArtboardChangedEvent = true);
 
 	void OnResourceInitialized_RenderThread(FRHICommandListImmediate& RHICmdList, FTextureRHIRef& NewResource) const;
 


### PR DESCRIPTION
We call InstantiateArtboard on URiveFile when URiveActor is ending or beginning play in editor. This makes it so that the artboard/state is reset and doesn't carry over.