### PR TITLE
UR-175: use asset import on rive import

### DIFF
--- a/Source/Rive/Private/Rive/RiveFile.cpp
+++ b/Source/Rive/Private/Rive/RiveFile.cpp
@@ -258,12 +258,12 @@ bool URiveFile::EditorImport(const FString& InRiveFilePath, TArray<uint8>& InRiv
 		UE_LOG(LogRive, Error, TEXT("Unable to Import the RiveFile '%s' as the RiveRenderer is null"), *InRiveFilePath);
 		return false;
 	}
-	
+	bNeedsImport = true;
 	RiveFilePath = InRiveFilePath;
 	RiveFileData = MoveTemp(InRiveFileBuffer);
 	SetFlags(RF_NeedPostLoad);
 	ConditionalPostLoad();
-
+	
 	// In Theory, the import should be synchronous as the IRiveRendererModule::Get().GetRenderer() should have been initialized,
 	// and the parent Rive File (if any) should already be loaded
 	ensureMsgf(WasLastInitializationSuccessful.IsSet(),
@@ -358,6 +358,22 @@ void URiveFile::Initialize()
 		if (ensure(PLSRenderContext))
 		{
 			ArtboardNames.Empty();
+			if (bNeedsImport)
+			{
+				bNeedsImport = false;
+				TUniquePtr<UE::Rive::Assets::FURAssetImporter> AssetImporter = MakeUnique<UE::Rive::Assets::FURAssetImporter>(GetOutermost(), RiveFilePath, GetAssets());
+				rive::ImportResult ImportResult;
+
+				FScopeLock Lock(&RiveRenderer->GetThreadDataCS());
+				RiveNativeFilePtr = rive::File::import(RiveNativeFileSpan, PLSRenderContext,
+										   &ImportResult, AssetImporter.Get());
+				if (ImportResult != rive::ImportResult::success)
+				{
+					UE_LOG(LogRive, Error, TEXT("Failed to import rive file."));
+					return;
+				}
+			}
+
 			if (!ParentRiveFile)
 			{
 				const TUniquePtr<UE::Rive::Assets::FURFileAssetLoader> FileAssetLoader = MakeUnique<

--- a/Source/Rive/Public/Rive/RiveFile.h
+++ b/Source/Rive/Public/Rive/RiveFile.h
@@ -265,4 +265,6 @@ private:
 	std::unique_ptr<rive::File> RiveNativeFilePtr;
 	
 	void PrintStats() const;
+
+	bool bNeedsImport = false;
 };

--- a/Source/RiveCore/Private/Assets/URFileAssetLoader.cpp
+++ b/Source/RiveCore/Private/Assets/URFileAssetLoader.cpp
@@ -23,6 +23,12 @@ UE::Rive::Assets::FURFileAssetLoader::FURFileAssetLoader(UObject* InOuter, TMap<
 bool UE::Rive::Assets::FURFileAssetLoader::loadContents(rive::FileAsset& InAsset, rive::Span<const uint8> InBandBytes,
                                                         rive::Factory* InFactory)
 {
+	// Just proceed to load the base type without processing it
+	if (InAsset.coreType() == rive::FileAssetBase::typeKey)
+	{
+		return true;
+	}
+	
 	const rive::Span<const uint8>* AssetBytes = &InBandBytes;
 	const bool bUseInBand = InBandBytes.size() > 0;
 	
@@ -44,6 +50,11 @@ bool UE::Rive::Assets::FURFileAssetLoader::loadContents(rive::FileAsset& InAsset
 		RiveAsset = NewObject<URiveAsset>(Outer, URiveAsset::StaticClass(),
 			MakeUniqueObjectName(Outer, URiveAsset::StaticClass(), FName{FString::Printf(TEXT("%d"),InAsset.assetId())}),
 			RF_Transient);
+
+		RiveAsset->Id = InAsset.assetId();
+		RiveAsset->Name = RiveAsset->GetName();
+		RiveAsset->Type = static_cast<ERiveAssetType>(InAsset.coreType());
+		RiveAsset->bIsInBand = true;
 	}
 	else
 	{


### PR DESCRIPTION
Bring back asset import: without this, out of band assets will fail to import and asset sharing will not work.