### PR TITLE
Ur 142 reduce logs

### DIFF
--- a/Source/Rive/Private/Logs/RiveLog.h
+++ b/Source/Rive/Private/Logs/RiveLog.h
@@ -2,4 +2,4 @@
 
 #pragma once
 
-DECLARE_LOG_CATEGORY_EXTERN(LogRive, VeryVerbose, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogRive, Display, All);

--- a/Source/Rive/Private/Slate/RiveSceneViewport.cpp
+++ b/Source/Rive/Private/Slate/RiveSceneViewport.cpp
@@ -23,7 +23,7 @@ FReply FRiveSceneViewport::OnMouseButtonDown(const FGeometry& MyGeometry, const 
 {
 	if (!RiveFile)
 	{
-		UE_LOG(LogRive, Warning, TEXT("Could not process FRiveSceneViewport::OnMouseButtonDown as we have an empty rive file."));
+		UE_LOG(LogRive, Verbose, TEXT("Could not process FRiveSceneViewport::OnMouseButtonDown as we have an empty rive file."));
 
 		return FReply::Unhandled();
 	}
@@ -46,7 +46,7 @@ FReply FRiveSceneViewport::OnMouseButtonDown(const FGeometry& MyGeometry, const 
 
 			if (StateMachine->OnMouseButtonDown(LocalPosition))
 			{
-				UE_LOG(LogRive, Warning, TEXT("Handled FRiveSceneViewport::OnMouseButtonDown at '%s'"), *LocalPosition.ToString())
+				UE_LOG(LogRive, Verbose, TEXT("Handled FRiveSceneViewport::OnMouseButtonDown at '%s'"), *LocalPosition.ToString())
 			}
 		}
 		Artboard->EndInput();
@@ -60,7 +60,7 @@ FReply FRiveSceneViewport::OnMouseButtonUp(const FGeometry& MyGeometry, const FP
 {
 	if (!RiveFile)
 	{
-		UE_LOG(LogRive, Warning, TEXT("Could not process FRiveSceneViewport::OnMouseButtonUp as we have an empty rive file."));
+		UE_LOG(LogRive, Verbose, TEXT("Could not process FRiveSceneViewport::OnMouseButtonUp as we have an empty rive file."));
 
 		return FReply::Unhandled();
 	}
@@ -83,7 +83,7 @@ FReply FRiveSceneViewport::OnMouseButtonUp(const FGeometry& MyGeometry, const FP
 
 			if (StateMachine->OnMouseButtonUp(LocalPosition))
 			{
-				UE_LOG(LogRive, Warning, TEXT("Handled FRiveSceneViewport::OnMouseButtonUp at '%s'"), *LocalPosition.ToString())
+				UE_LOG(LogRive, Verbose, TEXT("Handled FRiveSceneViewport::OnMouseButtonUp at '%s'"), *LocalPosition.ToString())
 			}
 		}
 		Artboard->EndInput();
@@ -97,7 +97,7 @@ FReply FRiveSceneViewport::OnMouseMove(const FGeometry& MyGeometry, const FPoint
 {
 	if (!RiveFile)
 	{
-		UE_LOG(LogRive, Warning, TEXT("Could not process FRiveSceneViewport::OnMouseMove as we have an empty rive file."));
+		UE_LOG(LogRive, Verbose, TEXT("Could not process FRiveSceneViewport::OnMouseMove as we have an empty rive file."));
 
 		return FReply::Unhandled();
 	}

--- a/Source/RiveCore/Private/Logs/RiveCoreLog.h
+++ b/Source/RiveCore/Private/Logs/RiveCoreLog.h
@@ -2,4 +2,4 @@
 
 #pragma once
 
-DECLARE_LOG_CATEGORY_EXTERN(LogRiveCore, VeryVerbose, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogRiveCore, Display, All);

--- a/Source/RiveEditor/Private/Logs/RiveEditorLog.h
+++ b/Source/RiveEditor/Private/Logs/RiveEditorLog.h
@@ -2,4 +2,4 @@
 
 #pragma once
 
-DECLARE_LOG_CATEGORY_EXTERN(LogRiveEditor, VeryVerbose, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogRiveEditor, Display, All);

--- a/Source/RiveEditor/Private/RiveEditorModule.cpp
+++ b/Source/RiveEditor/Private/RiveEditorModule.cpp
@@ -10,15 +10,12 @@
 
 void UE::Rive::Editor::Private::FRiveEditorModuleModule::StartupModule()
 {
-	if (GIsEditor)
-	{
-		UThumbnailManager::Get().RegisterCustomRenderer(URiveFile::StaticClass(), URiveTextureThumbnailRenderer::StaticClass());
-	}
+	UThumbnailManager::Get().RegisterCustomRenderer(URiveFile::StaticClass(), URiveTextureThumbnailRenderer::StaticClass());
 }
 
 void UE::Rive::Editor::Private::FRiveEditorModuleModule::ShutdownModule()
 {
-	if (UObjectInitialized() && GIsEditor)
+	if (UObjectInitialized())
 	{
 		UThumbnailManager::Get().UnregisterCustomRenderer(URiveFile::StaticClass());
 	}

--- a/Source/RiveEditor/Private/RiveEditorModule.cpp
+++ b/Source/RiveEditor/Private/RiveEditorModule.cpp
@@ -10,11 +10,18 @@
 
 void UE::Rive::Editor::Private::FRiveEditorModuleModule::StartupModule()
 {
-	UThumbnailManager::Get().RegisterCustomRenderer(URiveFile::StaticClass(), URiveTextureThumbnailRenderer::StaticClass());
+	if (GIsEditor)
+	{
+		UThumbnailManager::Get().RegisterCustomRenderer(URiveFile::StaticClass(), URiveTextureThumbnailRenderer::StaticClass());
+	}
 }
 
 void UE::Rive::Editor::Private::FRiveEditorModuleModule::ShutdownModule()
 {
+	if (UObjectInitialized() && GIsEditor)
+	{
+		UThumbnailManager::Get().UnregisterCustomRenderer(URiveFile::StaticClass());
+	}
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/RiveRenderer/Private/Logs/RiveRendererLog.h
+++ b/Source/RiveRenderer/Private/Logs/RiveRendererLog.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-DECLARE_LOG_CATEGORY_EXTERN(LogRiveRenderer, Log, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogRiveRenderer, Display, All);
 
 class FDebugLogger
 {

--- a/Source/RiveRenderer/Private/RiveRendererModule.cpp
+++ b/Source/RiveRenderer/Private/RiveRendererModule.cpp
@@ -47,11 +47,11 @@ void UE::Rive::Renderer::Private::FRiveRendererModule::StartupModule()
 #if PLATFORM_APPLE
         case ERHIInterfaceType::Metal:
         {
-            UE_LOG(LogRiveRenderer, Display, TEXT("Rive running on RHI 'Rive running on RHI 'Metal'"))
+            UE_LOG(LogRiveRenderer, Display, TEXT("Rive running on RHI 'Metal'"))
 #if defined(WITH_RIVE_MAC_ARM64)
-            RIVE_DEBUG_VERBOSE("Rive running on a Mac M1/M2 processor (Arm64)")
+            UE_LOG(LogRiveRenderer, Display, TEXT("Rive running on a Mac M1/M2 processor (Arm64)"))
 #elif defined(WITH_RIVE_MAC_INTEL)
-            RIVE_DEBUG_VERBOSE("Rive running on a Mac Intel processor (x86 x64)")
+            UE_LOG(LogRiveRenderer, Display, TEXT("Rive running on a Mac Intel processor (x86 x64)"))
 #endif
             RiveRenderer = MakeShared<FRiveRendererMetal>();
             break;


### PR DESCRIPTION
Defaulting our LogRive categories to Display instead, and updated Mouse input events to Verbose.

Logging can be changed by an end user by editing an .ini file to change the default logging settings for certain categories