### PR TITLE
reduce logging, default everything to Display

### DIFF
--- a/Source/Rive/Private/Logs/RiveLog.h
+++ b/Source/Rive/Private/Logs/RiveLog.h
@@ -2,4 +2,4 @@
 
 #pragma once
 
-DECLARE_LOG_CATEGORY_EXTERN(LogRive, VeryVerbose, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogRive, Display, All);

--- a/Source/Rive/Private/Slate/RiveSceneViewport.cpp
+++ b/Source/Rive/Private/Slate/RiveSceneViewport.cpp
@@ -23,7 +23,7 @@ FReply FRiveSceneViewport::OnMouseButtonDown(const FGeometry& MyGeometry, const 
 {
 	if (!RiveFile)
 	{
-		UE_LOG(LogRive, Warning, TEXT("Could not process FRiveSceneViewport::OnMouseButtonDown as we have an empty rive file."));
+		UE_LOG(LogRive, Verbose, TEXT("Could not process FRiveSceneViewport::OnMouseButtonDown as we have an empty rive file."));
 
 		return FReply::Unhandled();
 	}
@@ -46,7 +46,7 @@ FReply FRiveSceneViewport::OnMouseButtonDown(const FGeometry& MyGeometry, const 
 
 			if (StateMachine->OnMouseButtonDown(LocalPosition))
 			{
-				UE_LOG(LogRive, Warning, TEXT("Handled FRiveSceneViewport::OnMouseButtonDown at '%s'"), *LocalPosition.ToString())
+				UE_LOG(LogRive, Verbose, TEXT("Handled FRiveSceneViewport::OnMouseButtonDown at '%s'"), *LocalPosition.ToString())
 			}
 		}
 		Artboard->EndInput();
@@ -60,7 +60,7 @@ FReply FRiveSceneViewport::OnMouseButtonUp(const FGeometry& MyGeometry, const FP
 {
 	if (!RiveFile)
 	{
-		UE_LOG(LogRive, Warning, TEXT("Could not process FRiveSceneViewport::OnMouseButtonUp as we have an empty rive file."));
+		UE_LOG(LogRive, Verbose, TEXT("Could not process FRiveSceneViewport::OnMouseButtonUp as we have an empty rive file."));
 
 		return FReply::Unhandled();
 	}
@@ -83,7 +83,7 @@ FReply FRiveSceneViewport::OnMouseButtonUp(const FGeometry& MyGeometry, const FP
 
 			if (StateMachine->OnMouseButtonUp(LocalPosition))
 			{
-				UE_LOG(LogRive, Warning, TEXT("Handled FRiveSceneViewport::OnMouseButtonUp at '%s'"), *LocalPosition.ToString())
+				UE_LOG(LogRive, Verbose, TEXT("Handled FRiveSceneViewport::OnMouseButtonUp at '%s'"), *LocalPosition.ToString())
 			}
 		}
 		Artboard->EndInput();
@@ -97,7 +97,7 @@ FReply FRiveSceneViewport::OnMouseMove(const FGeometry& MyGeometry, const FPoint
 {
 	if (!RiveFile)
 	{
-		UE_LOG(LogRive, Warning, TEXT("Could not process FRiveSceneViewport::OnMouseMove as we have an empty rive file."));
+		UE_LOG(LogRive, Verbose, TEXT("Could not process FRiveSceneViewport::OnMouseMove as we have an empty rive file."));
 
 		return FReply::Unhandled();
 	}

--- a/Source/RiveCore/Private/Logs/RiveCoreLog.h
+++ b/Source/RiveCore/Private/Logs/RiveCoreLog.h
@@ -2,4 +2,4 @@
 
 #pragma once
 
-DECLARE_LOG_CATEGORY_EXTERN(LogRiveCore, VeryVerbose, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogRiveCore, Display, All);

--- a/Source/RiveEditor/Private/Logs/RiveEditorLog.h
+++ b/Source/RiveEditor/Private/Logs/RiveEditorLog.h
@@ -2,4 +2,4 @@
 
 #pragma once
 
-DECLARE_LOG_CATEGORY_EXTERN(LogRiveEditor, VeryVerbose, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogRiveEditor, Display, All);

--- a/Source/RiveRenderer/Private/Logs/RiveRendererLog.h
+++ b/Source/RiveRenderer/Private/Logs/RiveRendererLog.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-DECLARE_LOG_CATEGORY_EXTERN(LogRiveRenderer, Log, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogRiveRenderer, Display, All);
 
 class FDebugLogger
 {


### PR DESCRIPTION
Users can enable Verbose logging by updating the LogRive categories in their DefaultEngine ini if they choose to see higher detailed logging