### PR TITLE
Fix dangling pointer used for texture debug name

### DIFF
--- a/Source/Rive/Private/Rive/RiveTexture.cpp
+++ b/Source/Rive/Private/Rive/RiveTexture.cpp
@@ -176,9 +176,10 @@ void URiveTexture::InitializeResources() const
 		FScopeLock Lock(&RiveRenderer->GetThreadDataCS());
 		
 		FTextureRHIRef RenderableTexture;
+		const FString DebugName = GetName();
 
 		FRHITextureCreateDesc RenderTargetTextureDesc =
-			FRHITextureCreateDesc::Create2D(*GetName(), Size.X, Size.Y, Format)
+			FRHITextureCreateDesc::Create2D(*DebugName, Size.X, Size.Y, Format)
 				.SetClearValue(FClearValueBinding(FLinearColor(0.0f, 0.0f, 0.0f)))
 				.SetFlags(ETextureCreateFlags::Dynamic | ETextureCreateFlags::ShaderResource | ETextureCreateFlags::RenderTargetable);
 


### PR DESCRIPTION
The call to `GetName` creates a new `FString`, and we immediately use the `*` operator to get its `TCHAR*` buffer without storing the string. This means the string immediately falls out of scope, so `RenderTargetTextureDesc` ends up with a dangling pointer for its debug name. When running with `-stompmalloc`, this causes a crash on startup.

Moving the string to a const value outside the call site guarantees that the debug name buffer remains in scope until `RenderTargetTextureDesc` is destroyed at the end of the function call.