### PR TITLE
UR-229: CreateInstance in widget and RiveActor

### DIFF
--- a/Source/Rive/Private/Game/RiveActor.cpp
+++ b/Source/Rive/Private/Game/RiveActor.cpp
@@ -15,61 +15,18 @@ ARiveActor::ARiveActor()
 
 	RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("RootComponent0"));	
 	check(RootComponent);
-
-	RootComponent->Mobility = EComponentMobility::Movable;
 	
-	ScreenUserWidget = CreateDefaultSubobject<URiveFullScreenUserWidget>(TEXT("ScreenUserWidget"));
-	
-	ScreenUserWidget->SetDisplayTypes(ERiveWidgetDisplayType::Viewport, ERiveWidgetDisplayType::Viewport, ERiveWidgetDisplayType::Viewport);
-	
-	ScreenUserWidget->SetRiveActor(this);
-
-#if WITH_EDITOR
-	
-	RootComponent->bVisualizeComponent = true;
-
-#endif // WITH_EDITOR
-
 	AudioEngine = CreateDefaultSubobject<URiveAudioEngine>(TEXT("RiveAudioEngine"));
-	
-	RootComponent->SetMobility(EComponentMobility::Static);
-
-	PrimaryActorTick.bCanEverTick = true;
-
-	PrimaryActorTick.bStartWithTickEnabled = true;
-
-	bAllowTickBeforeBeginPlay = true;
-
-	SetActorTickEnabled(true);
-
-	SetHidden(false);
 }
 
 void ARiveActor::SetWidgetClass(TSubclassOf<UUserWidget> InWidgetClass)
 {
-	ScreenUserWidget->SetWidgetClass(InWidgetClass);
-}
-
-void ARiveActor::PostInitializeComponents()
-{
-	Super::PostInitializeComponents();
-
-#if WITH_EDITOR
-	
-	bEditorDisplayRequested = true;
-
-#endif //WITH_EDITOR
+	UserWidgetClass = InWidgetClass;
 }
 
 void ARiveActor::PostLoad()
 {
 	Super::PostLoad();
-
-#if WITH_EDITOR
-
-	bEditorDisplayRequested = true;
-
-#endif //WITH_EDITOR
 
 	if (RiveFile)
 	{
@@ -77,119 +34,34 @@ void ARiveActor::PostLoad()
 	}
 }
 
-void ARiveActor::PostActorCreated()
-{
-	Super::PostActorCreated();
-
-#if WITH_EDITOR
-	
-	bEditorDisplayRequested = true;
-
-#endif //WITH_EDITOR
-}
-
-void ARiveActor::Destroyed()
-{
-	if (ScreenUserWidget)
-	{
-		ScreenUserWidget->Hide();
-	}
-
-	Super::Destroyed();
-}
-
 void ARiveActor::BeginPlay()
 {
-	RequestGameDisplay();
-
-	UWorld* ActorWorld = GetWorld();
-
-	if (IsValid(RiveFile) && IsValid(ActorWorld) && (ActorWorld->WorldType == EWorldType::PIE))
-	{
-		RiveFile = RiveFile->CreateInstance(RiveFile->ArtboardName, RiveFile->StateMachineName);
-		RiveFile->InstantiateArtboard();
-		RiveFile->GetArtboard()->SetAudioEngine(AudioEngine);
-	}
-	
 	Super::BeginPlay();
+	
+	UWorld* ActorWorld = GetWorld();
+	
+	if (IsValid(RiveFile))
+	{
+		if (IsValid(ActorWorld) && (ActorWorld->WorldType == EWorldType::PIE))
+		{
+			RiveFile->InstantiateArtboard();
+		}
+
+		RiveFile->GetArtboard()->SetAudioEngine(AudioEngine);
+
+		ScreenUserWidget = CreateWidget(ActorWorld, UserWidgetClass);
+		ScreenUserWidget->AddToViewport();
+	}
 }
 
 void ARiveActor::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
-	Super::EndPlay(EndPlayReason);
-
-	if (ScreenUserWidget)
-	{
-		UWorld* ActorWorld = GetWorld();
-
-		if (ActorWorld && (ActorWorld->WorldType == EWorldType::Game || ActorWorld->WorldType == EWorldType::PIE))
-		{
-			ScreenUserWidget->Hide();
-		}
-	}
-
 	if (EndPlayReason == EEndPlayReason::EndPlayInEditor && IsValid(RiveFile))
 	{
-		if (RiveFile->ParentRiveFile != nullptr)
-		{
-			RiveFile = RiveFile->ParentRiveFile;
-		}
 		RiveFile->InstantiateArtboard();
 	}
-}
-
-void ARiveActor::Tick(float DeltaSeconds)
-{
-	Super::Tick(DeltaSeconds);
-
-#if WITH_EDITOR
-
-	if (bEditorDisplayRequested)
-	{
-		bEditorDisplayRequested = false;
-
-		RequestEditorDisplay();
-	}
-
-#endif //WITH_EDITOR
-
-	if (ScreenUserWidget)
-	{
-		ScreenUserWidget->Tick(DeltaSeconds);
-	}
-}
-
-void ARiveActor::RequestEditorDisplay()
-{
-#if WITH_EDITOR
-
-	UWorld* ActorWorld = GetWorld();
-
-	if (ScreenUserWidget && ActorWorld && ActorWorld->WorldType == EWorldType::Editor)
-	{
-		ScreenUserWidget->Display(ActorWorld);
-	}
-
-#endif //WITH_EDITOR
-}
-
-void ARiveActor::RequestGameDisplay()
-{
-	UWorld* ActorWorld = GetWorld();
 	
-	if (ScreenUserWidget && ActorWorld && (ActorWorld->WorldType == EWorldType::Game || ActorWorld->WorldType == EWorldType::PIE))
-	{
-		ScreenUserWidget->Display(ActorWorld);
-	}
-}
-
-UUserWidget* ARiveActor::GetUserWidget() const
-{
-	if (ScreenUserWidget)
-	{
-		return ScreenUserWidget->GetWidget();
-	}
-	return nullptr;
+	Super::EndPlay(EndPlayReason);
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/Rive/Private/Game/RiveActor.cpp
+++ b/Source/Rive/Private/Game/RiveActor.cpp
@@ -106,6 +106,7 @@ void ARiveActor::BeginPlay()
 
 	if (IsValid(RiveFile) && IsValid(ActorWorld) && (ActorWorld->WorldType == EWorldType::PIE))
 	{
+		RiveFile = RiveFile->CreateInstance(RiveFile->ArtboardName, RiveFile->StateMachineName);
 		RiveFile->InstantiateArtboard();
 		RiveFile->GetArtboard()->SetAudioEngine(AudioEngine);
 	}
@@ -129,6 +130,10 @@ void ARiveActor::EndPlay(const EEndPlayReason::Type EndPlayReason)
 
 	if (EndPlayReason == EEndPlayReason::EndPlayInEditor && IsValid(RiveFile))
 	{
+		if (RiveFile->ParentRiveFile != nullptr)
+		{
+			RiveFile = RiveFile->ParentRiveFile;
+		}
 		RiveFile->InstantiateArtboard();
 	}
 }

--- a/Source/Rive/Private/UMG/RiveWidget.cpp
+++ b/Source/Rive/Private/UMG/RiveWidget.cpp
@@ -1,6 +1,8 @@
 // Copyright Rive, Inc. All rights reserved.
 
 #include "UMG/RiveWidget.h"
+
+#include "Rive/RiveFile.h"
 #include "Slate/SRiveWidget.h"
 
 #define LOCTEXT_NAMESPACE "RiveWidget"
@@ -24,14 +26,14 @@ void URiveWidget::ReleaseSlateResources(bool bReleaseChildren)
 TSharedRef<SWidget> URiveWidget::RebuildWidget()
 {
     RiveWidget = SNew(SRiveWidget);
-    RiveWidget->SetRiveFile(RiveFile);
+    SetRiveFile(RiveFile);
 
     return RiveWidget.ToSharedRef();
 }
 
 void URiveWidget::SetRiveFile(URiveFile* InRiveFile)
 {
-    RiveFile = InRiveFile;
+    RiveFile = InRiveFile->CreateInstance(InRiveFile->ArtboardName, InRiveFile->StateMachineName);
 
     if (RiveWidget.IsValid())
     {

--- a/Source/Rive/Public/Game/RiveActor.h
+++ b/Source/Rive/Public/Game/RiveActor.h
@@ -27,45 +27,15 @@ public:
 public:
 
 	void SetWidgetClass(TSubclassOf<UUserWidget> InWidgetClass);
-
-	virtual void PostInitializeComponents() override;
-
 	virtual void PostLoad() override;
-
-	virtual void PostActorCreated() override;
-
-	virtual void Destroyed() override;
 
 	virtual void BeginPlay() override;
 
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
-	virtual void Tick(float DeltaSeconds) override;
-
-#if WITH_EDITOR
-
-	virtual bool ShouldTickIfViewportsOnly() const override { return true; }
-
-#endif //WITH_EDITOR
 
 	//~ END : AActor Interface
 
-	/**
-	 * Implementation(s)
-	 */
-
-public:
-
-	/* Get a pointer to the inner user widget  */
-	UFUNCTION(BlueprintCallable, Category = "User Interface")
-	UUserWidget* GetUserWidget() const;
-
-private:
-	
-	void RequestEditorDisplay();
-	
-	void RequestGameDisplay();
-	
 	/**
 	 * Attribute(s)
 	 */
@@ -75,11 +45,15 @@ public:
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Rive")
 	TObjectPtr<URiveFile> RiveFile;
 
+	/** Settings for Rive Rendering */
+	UPROPERTY(VisibleAnywhere, Category = "User Interface", meta = (ShowOnlyInnerProperties))
+	TSubclassOf<UUserWidget> UserWidgetClass;
+	
 protected:
 
 	/** Settings for Rive Rendering */
 	UPROPERTY(VisibleAnywhere, Instanced, NoClear, Category = "User Interface", meta = (ShowOnlyInnerProperties))
-	TObjectPtr<URiveFullScreenUserWidget> ScreenUserWidget;
+	TObjectPtr<UUserWidget> ScreenUserWidget;
 
 	UPROPERTY(VisibleAnywhere, Instanced, NoClear, Category = "Audio", meta = (ShowOnlyInnerProperties))
 	TObjectPtr<URiveAudioEngine> AudioEngine;


### PR DESCRIPTION
RiveFile, somewhere along the line, stopped allowing new instances of artboards to be created.

Without refactoring, we'll just use CreateInstance when we want unique variations of a rive file in the Widget and RiveActor.