### PR TITLE
Runtime Asset swapping

### DIFF
--- a/Source/Rive/Private/Rive/Assets/RiveAsset.cpp
+++ b/Source/Rive/Private/Rive/Assets/RiveAsset.cpp
@@ -2,12 +2,6 @@
 
 #include "Rive/Assets/RiveAsset.h"
 
-#include "Logs/RiveLog.h"
-#include "Misc/FileHelper.h"
-#include "rive/factory.hpp"
-#include "rive/assets/audio_asset.hpp"
-#include "rive/audio/audio_source.hpp"
-
 void URiveAsset::PostLoad()
 {
 	UObject::PostLoad();
@@ -27,70 +21,4 @@ void URiveAsset::PostLoad()
 		Type = ERiveAssetType::Font;
 		break;
 	}
-}
-
-void URiveAsset::LoadFromDisk()
-{
-	if (!FFileHelper::LoadFileToArray(NativeAssetBytes, *AssetPath))
-	{
-		UE_LOG(LogRive, Error, TEXT("Could not load Asset: %s at path %s"), *Name, *AssetPath);
-	}
-}
-
-bool URiveAsset::LoadNativeAsset(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes)
-{
-	switch(Type)
-	{
-	case ERiveAssetType::Font:
-		return DecodeFontAsset(InAsset, InRiveFactory, AssetBytes);
-	case ERiveAssetType::Image:
-		return DecodeImageAsset(InAsset, InRiveFactory, AssetBytes);
-	case ERiveAssetType::Audio:
-		return LoadAudioAsset(InAsset, InRiveFactory, AssetBytes);
-	}
-
-	return false;
-}
-
-bool URiveAsset::DecodeImageAsset(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes)
-{
-	rive::rcp<rive::RenderImage> DecodedImage = InRiveFactory->decodeImage(AssetBytes);
-
-	if (DecodedImage == nullptr)
-	{
-		UE_LOG(LogRive, Error, TEXT("Could not decode image asset: %s"), *Name);
-		return false;
-	}
-
-	rive::ImageAsset* ImageAsset = InAsset.as<rive::ImageAsset>();
-	ImageAsset->renderImage(DecodedImage);
-	NativeAsset = ImageAsset;
-	return true;
-}
-
-bool URiveAsset::DecodeFontAsset(rive::FileAsset& InAsset, rive::Factory* InRiveFactory,
-	const rive::Span<const uint8>& AssetBytes)
-{
-	rive::rcp<rive::Font> DecodedFont = InRiveFactory->decodeFont(AssetBytes);
-
-	if (DecodedFont == nullptr)
-	{
-		UE_LOG(LogRive, Error, TEXT("Could not decode font asset: %s"), *Name);
-		return false;
-	}
-
-	rive::FontAsset* FontAsset = InAsset.as<rive::FontAsset>();
-	FontAsset->font(DecodedFont);
-	NativeAsset = FontAsset;
-	return true;
-}
-
-bool URiveAsset::LoadAudioAsset(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes)
-{
-	rive::SimpleArray<uint8_t> Data = rive::SimpleArray(AssetBytes.data(), AssetBytes.count());
-	rive::AudioSource* AudioSource = new rive::AudioSource(Data);
-	rive::AudioAsset* AudioAsset = InAsset.as<rive::AudioAsset>();
-	AudioAsset->audioSource(ref_rcp(AudioSource));
-	NativeAsset = AudioAsset;
-	return true;
 }

--- a/Source/Rive/Private/Rive/Assets/RiveAudioAsset.cpp
+++ b/Source/Rive/Private/Rive/Assets/RiveAudioAsset.cpp
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright Rive, Inc. All rights reserved.
 
 
 #include "Rive/Assets/RiveAudioAsset.h"

--- a/Source/Rive/Private/Rive/Assets/RiveAudioAsset.cpp
+++ b/Source/Rive/Private/Rive/Assets/RiveAudioAsset.cpp
@@ -1,0 +1,27 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Rive/Assets/RiveAudioAsset.h"
+
+
+
+#include "PreRiveHeaders.h"
+THIRD_PARTY_INCLUDES_START
+#include "rive/assets/audio_asset.hpp"
+#include "rive/audio/audio_source.hpp"
+THIRD_PARTY_INCLUDES_END
+
+URiveAudioAsset::URiveAudioAsset()
+{
+	Type = ERiveAssetType::Audio;
+}
+
+bool URiveAudioAsset::LoadNativeAssetBytes(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes)
+{
+	rive::SimpleArray<uint8_t> Data = rive::SimpleArray(AssetBytes.data(), AssetBytes.count());
+	rive::AudioSource* AudioSource = new rive::AudioSource(Data);
+	rive::AudioAsset* AudioAsset = InAsset.as<rive::AudioAsset>();
+	AudioAsset->audioSource(ref_rcp(AudioSource));
+	NativeAsset = AudioAsset;
+	return true;
+}

--- a/Source/Rive/Private/Rive/Assets/RiveFileAssetLoader.cpp
+++ b/Source/Rive/Private/Rive/Assets/RiveFileAssetLoader.cpp
@@ -2,10 +2,14 @@
 
 #include "Rive/Assets/RiveFileAssetLoader.h"
 
+#include "AssetRegistry/AssetRegistryModule.h"
 #include "Logs/RiveLog.h"
 #include "Rive/Assets/RiveAsset.h"
 #include "Rive/Assets/RiveAssetHelpers.h"
 #include "rive/factory.hpp"
+#include "Rive/Assets/RiveAudioAsset.h"
+#include "Rive/Assets/RiveFontAsset.h"
+#include "Rive/Assets/RiveImageAsset.h"
 
 #if WITH_RIVE
 #include "PreRiveHeaders.h"
@@ -15,6 +19,92 @@ THIRD_PARTY_INCLUDES_START
 #include "rive/assets/image_asset.hpp"
 THIRD_PARTY_INCLUDES_END
 #endif // WITH_RIVE
+
+namespace UE::Private::RiveFileAssetLoader
+{
+	bool NeedsClassReplacement(URiveAsset* RiveAsset)
+	{
+		switch (RiveAsset->Type)
+		{
+		case ERiveAssetType::Font:
+			{
+				if (!Cast<URiveFontAsset>(RiveAsset))
+				{
+					return true;
+				}
+				break;
+			}
+
+		case ERiveAssetType::Audio:
+			{
+				if (!Cast<URiveAudioAsset>(RiveAsset))
+				{
+					return true;
+				}
+				break;
+			}
+		case ERiveAssetType::Image:
+			{
+				if (!Cast<URiveImageAsset>(RiveAsset))
+				{
+					return true;
+				}
+				break;
+			}
+		default:
+			break;
+		}
+		
+		return false;
+	}
+	
+	URiveAsset* ReplaceAsset(UObject* Outer, URiveAsset* RiveAsset)
+	{
+		URiveAsset* NewAsset = nullptr;
+		switch (RiveAsset->Type)
+		{
+		case ERiveAssetType::Font:
+			NewAsset = NewObject<URiveFontAsset>(Outer, URiveFontAsset::StaticClass(), NAME_None, RF_Public | RF_Standalone);
+			break;
+		case ERiveAssetType::Audio:
+			NewAsset = NewObject<URiveAudioAsset>(Outer, URiveAudioAsset::StaticClass(), NAME_None, RF_Public | RF_Standalone);
+			break;
+		case ERiveAssetType::Image:
+			NewAsset = NewObject<URiveImageAsset>(Outer, URiveImageAsset::StaticClass(), NAME_None, RF_Public | RF_Standalone);
+			break;
+		default:
+			break;
+		}
+
+		if (!NewAsset) return nullptr;
+		
+		UEngine::CopyPropertiesForUnrelatedObjects(RiveAsset, NewAsset);
+
+		UPackage* Package = RiveAsset->GetOutermost();
+		FString AssetPath = Package->GetPathName();
+		UPackage* NewPackage = CreatePackage(*AssetPath);
+
+		FString Name = RiveAsset->GetName();
+		const ERenameFlags PkgRenameFlags = REN_ForceNoResetLoaders | REN_DoNotDirty | REN_DontCreateRedirectors | REN_NonTransactional | REN_SkipGeneratedClasses;
+		RiveAsset->Rename(*FString::Printf(TEXT("%s_Old"), *Name), Package, PkgRenameFlags);
+		RiveAsset->ClearFlags(RF_Standalone | RF_Public);
+		RiveAsset->MarkAsGarbage();
+
+		
+		NewAsset->Rename(*Name, NewPackage);
+
+#if WITH_EDITOR
+		FAssetRegistryModule::AssetDeleted(RiveAsset);
+		FAssetRegistryModule::AssetCreated(NewAsset);
+		NewAsset->MarkPackageDirty();
+		UPackage::SavePackage(NewPackage, NewAsset, RF_Public | RF_Standalone, *FPackageName::LongPackageNameToFilename(AssetPath, FPackageName::GetAssetPackageExtension()));
+#endif
+		
+		
+		return NewAsset;
+	}
+	
+}
 
 FRiveFileAssetLoader::FRiveFileAssetLoader(UObject* InOuter, TMap<uint32, TObjectPtr<URiveAsset>>& InAssets)
 	: Outer(InOuter), Assets(InAssets)
@@ -45,6 +135,15 @@ bool FRiveFileAssetLoader::loadContents(rive::FileAsset& InAsset, rive::Span<con
 	if (RiveAssetPtr != nullptr && RiveAssetPtr->Get() != nullptr)
 	{
 		RiveAsset = RiveAssetPtr->Get();
+		
+		if (UE::Private::RiveFileAssetLoader::NeedsClassReplacement(RiveAsset))
+		{
+			if (URiveAsset* NewAsset = UE::Private::RiveFileAssetLoader::ReplaceAsset(Outer, RiveAsset))
+			{
+				RiveAsset = NewAsset;
+				Assets[InAsset.assetId()] = NewAsset;
+			}
+		}
 	}
 	else
 	{
@@ -53,14 +152,35 @@ bool FRiveFileAssetLoader::loadContents(rive::FileAsset& InAsset, rive::Span<con
 			UE_LOG(LogRive, Error, TEXT("Could not find pre-loaded asset. This means the initial import probably failed."));
 			return false;
 		}
-		
-		RiveAsset = NewObject<URiveAsset>(Outer, URiveAsset::StaticClass(),
+
+		ERiveAssetType Type = RiveAssetHelpers::GetUnrealType(InAsset.coreType());
+		switch (Type)
+		{
+		case ERiveAssetType::Audio:
+			RiveAsset = NewObject<URiveAudioAsset>(Outer, URiveAudioAsset::StaticClass(),
+			MakeUniqueObjectName(Outer, URiveAudioAsset::StaticClass(), FName{FString::Printf(TEXT("%d"),InAsset.assetId())}),
+			RF_Transient);
+			break;
+		case ERiveAssetType::Font:
+			RiveAsset = NewObject<URiveFontAsset>(Outer, URiveFontAsset::StaticClass(),
+			MakeUniqueObjectName(Outer, URiveFontAsset::StaticClass(), FName{FString::Printf(TEXT("%d"),InAsset.assetId())}),
+			RF_Transient);
+			break;
+		case ERiveAssetType::Image:
+			RiveAsset = NewObject<URiveImageAsset>(Outer, URiveImageAsset::StaticClass(),
+			MakeUniqueObjectName(Outer, URiveImageAsset::StaticClass(), FName{FString::Printf(TEXT("%d"),InAsset.assetId())}),
+			RF_Transient);
+			break;
+		default:
+			RiveAsset = NewObject<URiveAsset>(Outer, URiveAsset::StaticClass(),
 			MakeUniqueObjectName(Outer, URiveAsset::StaticClass(), FName{FString::Printf(TEXT("%d"),InAsset.assetId())}),
 			RF_Transient);
-
+			break;
+		}
+		
 		RiveAsset->Id = InAsset.assetId();
 		RiveAsset->Name = FString(UTF8_TO_TCHAR(InAsset.name().c_str()));
-		RiveAsset->Type = RiveAssetHelpers::GetUnrealType(InAsset.coreType()); 
+		RiveAsset->Type = Type;
 		RiveAsset->bIsInBand = true;
 
 		// We only add it to our assets here so that it shows up in the inspector, otherwise this doesn't have any functional effect on anything due to it being a transient, in-band asset
@@ -79,7 +199,7 @@ bool FRiveFileAssetLoader::loadContents(rive::FileAsset& InAsset, rive::Span<con
 		AssetBytes = &OutOfBandBytes;
 	}
 
-	return RiveAsset->LoadNativeAsset(InAsset, InFactory, *AssetBytes);
+	return RiveAsset->LoadNativeAssetBytes(InAsset, InFactory, *AssetBytes);
 }
 
 #endif // WITH_RIVE

--- a/Source/Rive/Private/Rive/Assets/RiveFontAsset.cpp
+++ b/Source/Rive/Private/Rive/Assets/RiveFontAsset.cpp
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright Rive, Inc. All rights reserved.
 
 
 #include "Rive/Assets/RiveFontAsset.h"

--- a/Source/Rive/Private/Rive/Assets/RiveFontAsset.cpp
+++ b/Source/Rive/Private/Rive/Assets/RiveFontAsset.cpp
@@ -1,0 +1,90 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Rive/Assets/RiveFontAsset.h"
+
+#include "IRiveRenderer.h"
+#include "IRiveRendererModule.h"
+#include "Engine/Font.h"
+#include "Logs/RiveLog.h"
+
+#include "PreRiveHeaders.h"
+#include "Engine/FontFace.h"
+THIRD_PARTY_INCLUDES_START
+#include "rive/pls/pls_render_context.hpp"
+THIRD_PARTY_INCLUDES_END
+
+
+URiveFontAsset::URiveFontAsset()
+{
+	Type = ERiveAssetType::Font;
+}
+
+void URiveFontAsset::LoadFontFace(UFontFace* InFontFace)
+{
+	if (!InFontFace || Type != ERiveAssetType::Font)
+	{
+		return;
+	}
+
+	if (InFontFace->LoadingPolicy != EFontLoadingPolicy::Inline)
+	{
+		UE_LOG(LogRive, Warning, TEXT("LoadFontFace: trying to load a font that isn't marked Inline, this will fail. Please change the FontFace to use the 'Inline' Loading Policy."));
+		return;
+	}
+
+	if (InFontFace->FontFaceData->HasData() && InFontFace->FontFaceData->GetData().Num() > 0)
+	{
+		LoadFontBytes(InFontFace->FontFaceData->GetData());
+	} else
+	{
+		UE_LOG(LogRive, Warning, TEXT("LoadFontFace: FontFace has no data to decode."));
+	}
+}
+
+void URiveFontAsset::LoadFontBytes(const TArray<uint8>& InBytes)
+{
+	IRiveRenderer* RiveRenderer = IRiveRendererModule::Get().GetRenderer();
+
+	// We'll copy InBytes into the lambda because there's no guarantee they'll exist by the time it's hit
+	RiveRenderer->CallOrRegister_OnInitialized(IRiveRenderer::FOnRendererInitialized::FDelegate::CreateLambda(
+		[this, InBytes](IRiveRenderer* RiveRenderer)
+		{
+			rive::pls::PLSRenderContext* PLSRenderContext;
+			{
+				FScopeLock Lock(&RiveRenderer->GetThreadDataCS());
+				PLSRenderContext = RiveRenderer->GetPLSRenderContextPtr();
+			}
+	
+			if (ensure(PLSRenderContext))
+			{
+				auto DecodedFont = PLSRenderContext->decodeFont(rive::make_span(InBytes.GetData(), InBytes.Num()));
+			
+				if (DecodedFont == nullptr)
+				{
+					UE_LOG(LogRive, Error, TEXT("LoadFontFace: Could not decode font bytes"));
+					return;
+				}
+									
+				rive::FontAsset* FontAsset = NativeAsset->as<rive::FontAsset>();
+				FontAsset->font(DecodedFont);
+			}
+		}
+	));
+}
+
+bool URiveFontAsset::LoadNativeAssetBytes(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes)
+{
+	rive::rcp<rive::Font> DecodedFont = InRiveFactory->decodeFont(AssetBytes);
+
+	if (DecodedFont == nullptr)
+	{
+		UE_LOG(LogRive, Error, TEXT("Could not decode font asset: %s"), *Name);
+		return false;
+	}
+
+	rive::FontAsset* FontAsset = InAsset.as<rive::FontAsset>();
+	FontAsset->font(DecodedFont);
+	NativeAsset = FontAsset;
+	return true;
+}

--- a/Source/Rive/Private/Rive/Assets/RiveImageAsset.cpp
+++ b/Source/Rive/Private/Rive/Assets/RiveImageAsset.cpp
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright Rive, Inc. All rights reserved.
 
 #include "Rive/Assets/RiveImageAsset.h"
 

--- a/Source/Rive/Private/Rive/Assets/RiveImageAsset.cpp
+++ b/Source/Rive/Private/Rive/Assets/RiveImageAsset.cpp
@@ -1,0 +1,102 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "Rive/Assets/RiveImageAsset.h"
+
+#include "IRiveRenderer.h"
+#include "IRiveRendererModule.h"
+#include "Logs/RiveLog.h"
+
+#include "PreRiveHeaders.h"
+#include "rive/pls/pls_render_context_impl.hpp"
+THIRD_PARTY_INCLUDES_START
+#include "rive/factory.hpp"
+#include "rive/pls/pls_render_context.hpp"
+THIRD_PARTY_INCLUDES_END
+
+
+URiveImageAsset::URiveImageAsset()
+{
+	Type = ERiveAssetType::Image;
+}
+
+void URiveImageAsset::LoadTexture(UTexture2D* InTexture)
+{
+	if (!InTexture) return;
+
+	IRiveRenderer* RiveRenderer = IRiveRendererModule::Get().GetRenderer();
+
+	RiveRenderer->CallOrRegister_OnInitialized(IRiveRenderer::FOnRendererInitialized::FDelegate::CreateLambda(
+		[this, InTexture](IRiveRenderer* RiveRenderer)
+		{
+			rive::pls::PLSRenderContext* PLSRenderContext;
+			{
+				FScopeLock Lock(&RiveRenderer->GetThreadDataCS());
+				PLSRenderContext = RiveRenderer->GetPLSRenderContextPtr();
+			}
+
+			if (ensure(PLSRenderContext))
+			{
+				InTexture->SetForceMipLevelsToBeResident(30.f);
+				InTexture->WaitForStreaming();
+
+				EPixelFormat PixelFormat = InTexture->GetPixelFormat();
+				if (PixelFormat != PF_R8G8B8A8)
+				{
+					UE_LOG(LogRive, Error, TEXT("Error loading Texture '%s': Rive only supports RGBA pixel formats. This texture is of format"), *InTexture->GetName())
+					return;
+				}
+
+				FTexture2DMipMap& Mip = InTexture->GetPlatformData()->Mips[0];
+				uint8* MipData = reinterpret_cast<uint8*>(Mip.BulkData.Lock(LOCK_READ_ONLY));
+				int32 BitmapDataSize = Mip.SizeX * Mip.SizeY * sizeof(FColor);
+
+				TArray<uint8> BitmapData;
+				BitmapData.AddUninitialized(BitmapDataSize);
+				FMemory::Memcpy(BitmapData.GetData(), MipData, BitmapDataSize);
+				Mip.BulkData.Unlock();
+
+				if (MipData == nullptr)
+				{
+					UE_LOG(LogRive, Error, TEXT("Unable to load Mip data for %s"), *InTexture->GetName());
+					return;
+				}
+
+
+				// decodeImage() here requires encoded bytes and returns a rive::RenderImage
+				// it will call:
+				//   PLSRenderContextHelperImpl::decodeImageTexture() ->
+				//     Bitmap::decode()
+				//       // here, Bitmap only decodes webp, jpg, png and discards otherwise
+				rive::rcp<rive::RenderImage> DecodedImage = PLSRenderContext->decodeImage(rive::make_span(BitmapData.GetData(), BitmapDataSize));
+
+				// This is what we need, to make a RenderImage and supply raw bitmap bytes that aren't already encoded:
+				// makeImage, createImage, or any other descriptive name could be used
+				// rive::rcp<rive::RenderImage> RenderImage = PLSRenderContext->makeImage(rive::make_span(BitmapData.GetData(), BitmapDataSize));
+
+				if (DecodedImage == nullptr)
+				{
+					UE_LOG(LogRive, Error, TEXT("Could not decode image asset: %s"), *InTexture->GetName());
+					return;
+				}
+
+				NativeAsset->as<rive::ImageAsset>()->renderImage(DecodedImage);
+			}
+		}
+	));
+}
+
+bool URiveImageAsset::LoadNativeAssetBytes(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes)
+{
+	rive::rcp<rive::RenderImage> DecodedImage = InRiveFactory->decodeImage(AssetBytes);
+
+	if (DecodedImage == nullptr)
+	{
+		UE_LOG(LogRive, Error, TEXT("Could not decode image asset: %s"), *Name);
+		return false;
+	}
+
+	rive::ImageAsset* ImageAsset = InAsset.as<rive::ImageAsset>();
+	ImageAsset->renderImage(DecodedImage);
+	NativeAsset = ImageAsset;
+	return true;
+}

--- a/Source/Rive/Public/Rive/Assets/RiveAsset.h
+++ b/Source/Rive/Public/Rive/Assets/RiveAsset.h
@@ -34,7 +34,8 @@ class RIVE_API URiveAsset : public UObject
 
 public:
 	virtual void PostLoad() override;
-
+	virtual bool LoadNativeAssetBytes(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes) { return false; }
+	
 	UPROPERTY(VisibleAnywhere, Category=Rive, meta=(NoResetToDefault))
 	uint32 Id;
 	
@@ -55,17 +56,6 @@ public:
 	
 	UPROPERTY()
 	TArray<uint8> NativeAssetBytes;
-
-#if WITH_RIVE
+	
 	rive::Asset* NativeAsset;
-#else
-	void* NativeAsset;
-#endif
-
-	void LoadFromDisk();
-	bool LoadNativeAsset(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes);
-private:
-	bool DecodeImageAsset(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes);
-	bool DecodeFontAsset(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes);
-	bool LoadAudioAsset(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes);
 };

--- a/Source/Rive/Public/Rive/Assets/RiveAudioAsset.h
+++ b/Source/Rive/Public/Rive/Assets/RiveAudioAsset.h
@@ -1,0 +1,19 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RiveAsset.h"
+#include "RiveAudioAsset.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class RIVE_API URiveAudioAsset : public URiveAsset
+{
+	GENERATED_BODY()
+
+	URiveAudioAsset();
+	virtual bool LoadNativeAssetBytes(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes) override;
+};

--- a/Source/Rive/Public/Rive/Assets/RiveFontAsset.h
+++ b/Source/Rive/Public/Rive/Assets/RiveFontAsset.h
@@ -1,0 +1,28 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RiveAsset.h"
+#include "RiveFontAsset.generated.h"
+
+class UFontFace;
+/**
+ * 
+ */
+UCLASS()
+class RIVE_API URiveFontAsset : public URiveAsset
+{
+	GENERATED_BODY()
+	
+	URiveFontAsset();
+	
+	UFUNCTION(BlueprintCallable, Category=Rive)
+	void LoadFontFace(UFontFace* InFont);
+
+	UFUNCTION(BlueprintCallable, Category=Rive)
+	void LoadFontBytes(const TArray<uint8>& InBytes);
+
+	virtual bool LoadNativeAssetBytes(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes) override;
+
+};

--- a/Source/Rive/Public/Rive/Assets/RiveImageAsset.h
+++ b/Source/Rive/Public/Rive/Assets/RiveImageAsset.h
@@ -19,5 +19,8 @@ class RIVE_API URiveImageAsset : public URiveAsset
 	UFUNCTION(BlueprintCallable)
 	void LoadTexture(UTexture2D* InTexture);
 
+	UFUNCTION(BlueprintCallable, Category=Rive)
+	void LoadImageBytes(const TArray<uint8>& InBytes);
+
 	virtual bool LoadNativeAssetBytes(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes) override;
 };

--- a/Source/Rive/Public/Rive/Assets/RiveImageAsset.h
+++ b/Source/Rive/Public/Rive/Assets/RiveImageAsset.h
@@ -1,0 +1,23 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RiveAsset.h"
+#include "RiveImageAsset.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class RIVE_API URiveImageAsset : public URiveAsset
+{
+	GENERATED_BODY()
+
+	URiveImageAsset();
+
+	UFUNCTION(BlueprintCallable)
+	void LoadTexture(UTexture2D* InTexture);
+
+	virtual bool LoadNativeAssetBytes(rive::FileAsset& InAsset, rive::Factory* InRiveFactory, const rive::Span<const uint8>& AssetBytes) override;
+};

--- a/Source/Rive/Public/Rive/Assets/RiveImageAsset.h
+++ b/Source/Rive/Public/Rive/Assets/RiveImageAsset.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright Rive, Inc. All rights reserved.
 
 #pragma once
 
@@ -16,7 +16,7 @@ class RIVE_API URiveImageAsset : public URiveAsset
 
 	URiveImageAsset();
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category=Rive)
 	void LoadTexture(UTexture2D* InTexture);
 
 	UFUNCTION(BlueprintCallable, Category=Rive)

--- a/Source/Rive/Public/Rive/RiveFile.h
+++ b/Source/Rive/Public/Rive/RiveFile.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "UObject/Object.h"
 #include "RiveTypes.h"
+#include "Assets/RiveAsset.h"
 
 #if WITH_RIVE
 #include "PreRiveHeaders.h"
@@ -102,6 +103,20 @@ public:
 	TMap<uint32, TObjectPtr<URiveAsset>>& GetAssets()
 	{
 		return Assets;
+	}
+
+	UFUNCTION(BlueprintCallable, Category=Rive)
+	URiveAsset* GetRiveAssetById(int32 InId) const
+	{
+		for (const TTuple<unsigned int, TObjectPtr<URiveAsset>>& x : Assets)
+		{
+			if (x.Value->Id == InId)
+			{
+				return x.Value;
+			}
+		}
+
+		return nullptr;
 	}
 	
 	rive::Span<const uint8> RiveNativeFileSpan;


### PR DESCRIPTION
- RiveAsset class was broken into 3 classes
  - RiveAudioAsset 
  - RiveImageAsset, contains runtime compatible functions:
    - LoadImageBytes (accepting an array of bytes in png, webp, jpg format)
    - LoadTexture (not yet implemented fully, as we wait on Rive to allow us to submit bitmap data) 
  - RiveFontAsset, contains runtime compatible functions:
    - LoadFontFace (loads an Unreal font face, if the font face's load policy is set to Inline)
    - LoadFontBytes (accepting an array of bytes in ttf/otf format)
- RiveFile now supports a function "GetRiveAssetById", returning a base RiveAsset which can later be cast to one of the specific asset types to operate on
