### PR TITLE
Put GRHISupportsRasterOrderViews behind capability checks

### DIFF
--- a/Source/RiveRenderer/Private/Platform/RenderContextRHIImpl.cpp
+++ b/Source/RiveRenderer/Private/Platform/RenderContextRHIImpl.cpp
@@ -305,7 +305,9 @@ void AddVisualizeBufferPass(FRHICommandList& CommandList,
 RHICapabilities::RHICapabilities()
 {
     bSupportsPixelShaderUAVs = GRHISupportsPixelShaderUAVs;
+#if defined(PLATFORM_WINDOWS) && defined(D3D12)
     bSupportsRasterOrderViews = GRHISupportsRasterOrderViews;
+#endif
     bSupportsTypedUAVLoads =
         UE::PixelFormat::HasCapabilities(PF_R8G8B8A8,
                                          EPixelFormatCapabilities::UAV) &&


### PR DESCRIPTION
Fixes #121 

Failing build because of missing declaration for GRHISupportsRasterOrderViews. The PR guards the usage behind DX12 check.