### PR TITLE
Fix deprecated error "All definitions have been moved to Stats.h, ple…

### DIFF
--- a/Source/RiveEditor/Private/Stats/RiveEditorStats.h
+++ b/Source/RiveEditor/Private/Stats/RiveEditorStats.h
@@ -2,6 +2,6 @@
 
 #pragma once
 
-#include "Stats/Stats2.h"
+#include "Stats/Stats.h"
 
 DECLARE_STATS_GROUP(TEXT("RiveEditor"), STATGROUP_RiveEditor, STATCAT_Advanced);


### PR DESCRIPTION
Fix deprecated error "All definitions have been moved to Stats.h, please use that instead."